### PR TITLE
Disable compile warnings as errors to compile on ubuntu 11.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ IF (CMAKE_COMPILER_IS_GNUCXX )
     SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -g")
     MESSAGE ("SSE 4.1  SUPPORT OFF")
   ENDIF()
-  ADD_DEFINITIONS("-Wall -Werror -Wno-unused-variable
+  ADD_DEFINITIONS("-Wall -Wno-unused-variable
                    -Wno-unused-but-set-variable -Wno-unknown-pragmas")
 ENDIF()
 


### PR DESCRIPTION
Compiling on Ubuntu 11.10 was failing with:

<pre>/usr/bin/c++    -O3 -g -I/home/tim/svslocal/include/opencv -I/home/tim/svslocal/include -I/usr/include/eigen3 -I/usr/include/suitesparse    -Wall -Werror -Wno-unused-variable                    -Wno-unused-but-set-variable -Wno-unknown-pragmas -o CMakeFiles/stereo_slam.dir/scavislam/stereo_slam.cpp.o -c /home/tim/svslocal/ScaViSLAM/scavislam/stereo_slam.cpp
/home/tim/svslocal/ScaViSLAM/scavislam/stereo_slam.cpp: In function ‘Views initializeViews(const ScaViSLAM::StereoCamera&)’:
/home/tim/svslocal/ScaViSLAM/scavislam/stereo_slam.cpp:145:61: error: ‘pangolin::OpenGlRenderState& pangolin::OpenGlRenderState::Set(pangolin::OpenGlMatrixSpec)’ is deprecated (declared at /home/tim/svslocal/include/pangolin/opengl_render_state.h:167) [-Werror=deprecated-declarations]
/home/tim/svslocal/ScaViSLAM/scavislam/stereo_slam.cpp:146:78: error: ‘pangolin::OpenGlRenderState& pangolin::OpenGlRenderState::Set(pangolin::OpenGlMatrixSpec)’ is deprecated (declared at /home/tim/svslocal/include/pangolin/opengl_render_state.h:167) [-Werror=deprecated-declarations]
cc1plus: all warnings being treated as errors</pre>